### PR TITLE
Refatoração - Transformando  Classe Crypto em um Singleton

### DIFF
--- a/Infrastructure/Data/Repositories/Implementations/UsuarioRepositorioImpl.cs
+++ b/Infrastructure/Data/Repositories/Implementations/UsuarioRepositorioImpl.cs
@@ -29,7 +29,7 @@ namespace despesas_backend_api_net_core.Infrastructure.Data.Repositories.Impleme
                     Login = item.Email,
                     UsuarioId = item.Id,
                     Usuario = item,
-                    Senha = Crypto.Encrypt(Guid.NewGuid().ToString().Substring(0, 8))
+                    Senha = Crypto.GetInstance.Encrypt(Guid.NewGuid().ToString().Substring(0, 8))
                 };
                 dsControleACesso.Add(controleAcesso);
 

--- a/Infrastructure/Security/Configuration/Crypto.cs
+++ b/Infrastructure/Security/Configuration/Crypto.cs
@@ -1,18 +1,27 @@
-﻿using System.Configuration;
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 
 namespace despesas_backend_api_net_core.Infrastructure.Security.Configuration
 {
     public class Crypto
-    {   
+    {
         private static byte[] Key; // Chave fixa de 256 bits
-
-        public Crypto(byte[] _key)
+        private static Crypto? Instance;
+        private Crypto() { }
+        public static Crypto GetInstance 
         {
-            Key = _key;
+            get
+            {
+                return Instance == null ? new() : Instance;
+            }
+        
         }
-        public static string Encrypt(string password)
+
+        public void SetCryptoKey(string _key)
+        {
+            Key = Convert.FromBase64String(_key);
+        }
+        public string Encrypt(string password)
         {
             byte[] iv = GenerateIV();
 
@@ -32,7 +41,7 @@ namespace despesas_backend_api_net_core.Infrastructure.Security.Configuration
             }
         }
 
-        public static string Decrypt(string encryptedText)
+        public string Decrypt(string encryptedText)
         {
             byte[] encryptedData = Convert.FromBase64String(encryptedText);
             byte[] iv = new byte[16];

--- a/Program.cs
+++ b/Program.cs
@@ -123,8 +123,7 @@ static void ConfigureAutorization(IServiceCollection services, IConfiguration co
 }
 static void ConfigureCrypto(IServiceCollection services, IConfiguration configuration)
 {
-    var key = Convert.FromBase64String(configuration.GetSection("Crypto:Key").Value);
-    new Crypto(key);
+    Crypto.GetInstance.SetCryptoKey(configuration.GetSection("Crypto:Key").Value);
 }
 static void ConfigureAmazonS3Access(IServiceCollection services, IConfiguration configuration)
 {


### PR DESCRIPTION
Classe Crypto foi transformado em um Singleton protegendo e garantindo assim que haja apenas uma instancia da classe na aplicação. Foi criado um método chamado SetCryptoKey  que recebe uma string representando a chave de criptografia e converte para o tipo byte encapsulando assim a implementação e removendo da classe responsável por instancia ou inicializar a API. Modificações no restante do código foram implementadas principalmente na Classe Repositório Controle de Acesso que utiliza a classe para realizar CRUD e validação das senhas  usuário, também ouve modificações na Classe Repositório Usuário que realiza a criação de usuário chamando a Instancia da Cryto apenas no momento em que é realizado Insert dos dados no banco de dados. 